### PR TITLE
Replace deprecated API usage in SecurityConfiguration

### DIFF
--- a/src/main/java/my/app/security/SecurityConfiguration.java
+++ b/src/main/java/my/app/security/SecurityConfiguration.java
@@ -22,7 +22,7 @@ public class SecurityConfiguration extends VaadinWebSecurity {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
-        http.authorizeHttpRequests().requestMatchers(new AntPathRequestMatcher("/images/*.png")).permitAll();
+        http.authorizeHttpRequests(authorize -> authorize.requestMatchers(new AntPathRequestMatcher("/images/*.png")).permitAll());
         super.configure(http);
         setLoginView(http, LoginView.class);
     }


### PR DESCRIPTION
`HttpSecurity.authorizeHttpRequests()` has been [deprecated](https://docs.spring.io/spring-security/site/docs/6.1.0/api/org/springframework/security/config/annotation/web/builders/HttpSecurity.html#authorizeHttpRequests()) in Spring 6.1 and is planned to be removed in Spring 7.0. It is recommended to use `HttpSecurity.authorizeHttpRequests(Customizer)` instead